### PR TITLE
 chore(linear-gradient): fix equality comparer

### DIFF
--- a/apps/app/ui-tests-app/css/background-image-linear-gradient.ts
+++ b/apps/app/ui-tests-app/css/background-image-linear-gradient.ts
@@ -1,0 +1,41 @@
+import * as pages from "tns-core-modules/ui/page";
+import { EventData } from "tns-core-modules/data/observable";
+import * as button from "tns-core-modules/ui/button";
+
+import { GridLayout } from "tns-core-modules/ui/layouts/grid-layout";
+
+let testIndex = 0;
+const tests = [
+    { name: "black-blue only", backgroundImage: "linear-gradient(to bottom, black, blue)"},
+    { name: "to bottom green-blue", backgroundImage: "linear-gradient(to bottom, green, blue)"},
+    { name: "to left yellow-blue", backgroundImage: "linear-gradient(to left, yellow, green)"},
+    { name: "to right yellow-blue", backgroundImage: "linear-gradient(to right, yellow, green)"},
+    { name: "-45deg green-blue", backgroundImage: "linear-gradient(-45deg, green, blue)"},
+    { name: "45deg green-blue", backgroundImage: "linear-gradient(45deg, green, blue)"},
+
+    { name: "black-blue-pink only", backgroundImage: "linear-gradient(to bottom, black, blue, pink)"},
+    { name: "to bottom green-blue-pink", backgroundImage: "linear-gradient(to bottom, green, blue, pink)"},
+    { name: "to left yellow-blue-pink", backgroundImage: "linear-gradient(to left, yellow, green, pink)"},
+    { name: "to right yellow-blue-pink", backgroundImage: "linear-gradient(to right, yellow, green, pink)"},
+    { name: "-45deg green-blue-pink", backgroundImage: "linear-gradient(-45deg, green, blue, pink)"},
+    { name: "45deg green-blue-pink", backgroundImage: "linear-gradient(45deg, green, blue, pink)"},
+]
+
+export function onLoaded(args) {
+    applyNextStyle(args);
+}
+
+export function onButtonTap(args) {
+    applyNextStyle(args);
+}
+
+function applyNextStyle(args) {
+    let page = <pages.Page>args.object.page;
+    let btn = <button.Button>args.object;
+    let gridElement = <GridLayout>page.getViewById("Container");
+
+    btn.text = tests[testIndex].name;
+    gridElement.backgroundImage = tests[testIndex].backgroundImage;
+
+    testIndex = testIndex < tests.length - 1 ? ++testIndex : 0;
+}

--- a/apps/app/ui-tests-app/css/background-image-linear-gradient.xml
+++ b/apps/app/ui-tests-app/css/background-image-linear-gradient.xml
@@ -1,0 +1,7 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" loaded="onLoaded">
+  <GridLayout rows="*, 7*">
+     <Button row="0" text="a1" tap="onButtonTap"/>
+
+    <GridLayout id="Container" fontSize="12" borderColor="black" margin="5" borderWidth="1" row="1"/>
+  </GridLayout>
+</Page>

--- a/apps/app/ui-tests-app/css/main-page.ts
+++ b/apps/app/ui-tests-app/css/main-page.ts
@@ -42,5 +42,6 @@ export function loadExamples() {
     examples.set("non-uniform-radius", "css/non-uniform-radius");
     examples.set("missing-background-image", "css/missing-background-image");
     examples.set("background-shorthand", "css/background-shorthand");
+    examples.set("background-image-linear-gradient", "css/background-image-linear-gradient");
     return examples;
 }

--- a/tns-core-modules/ui/styling/linear-gradient.ts
+++ b/tns-core-modules/ui/styling/linear-gradient.ts
@@ -36,11 +36,11 @@ export class LinearGradient {
         }
 
         if (first.angle !== second.angle) {
-            return true;
+            return false;
         }
 
         if (first.colorStops.length !== second.colorStops.length) {
-            return true;
+            return false;
         }
 
         for (let i = 0; i < first.colorStops.length; i++) {


### PR DESCRIPTION
@vultix I think equality comparer should return `false` when angle or `colorStops` are different otherwise it fails to apply new gradient with different position (to left, to right e.g.).

Add linear gradient test app with dynamically changing `backgroundImage` property

P.S: Great feature!